### PR TITLE
[Feat] ChakraInput 컴포넌트 추가

### DIFF
--- a/src/components/base/ChakraInput.tsx
+++ b/src/components/base/ChakraInput.tsx
@@ -1,0 +1,26 @@
+import { Input } from "@chakra-ui/react";
+
+type inputTypes = {
+  text: string;
+  size?: string;
+  width?: number;
+  type?: string;
+};
+
+const ChakraInput = ({
+  text,
+  size = "lg",
+  width = 400,
+  type = "text",
+}: inputTypes) => {
+  return (
+    <Input
+      type={type}
+      placeholder={text}
+      size={size}
+      width={width ? width : undefined}
+    />
+  );
+};
+
+export default ChakraInput;

--- a/src/components/base/ChakraInput.tsx
+++ b/src/components/base/ChakraInput.tsx
@@ -5,6 +5,8 @@ type inputTypes = {
   size?: string;
   width?: number;
   type?: string;
+  variant?: string;
+  bgColor?: string;
 };
 
 const ChakraInput = ({
@@ -12,13 +14,18 @@ const ChakraInput = ({
   size = "lg",
   width = 400,
   type = "text",
+  variant = "outline",
+  bgColor = "#FFFFFF",
 }: inputTypes) => {
   return (
     <Input
       type={type}
       placeholder={text}
       size={size}
-      width={width ? width : undefined}
+      width={width}
+      variant={variant}
+      bg={bgColor}
+      _hover={{ bg: bgColor }}
     />
   );
 };

--- a/src/stories/ChakraInput.stories.tsx
+++ b/src/stories/ChakraInput.stories.tsx
@@ -14,6 +14,14 @@ export default {
       defaultValue: "text",
       control: "text",
     },
+    variant: {
+      defaultValue: "outline",
+      control: "text",
+    },
+    bgColor: {
+      defaultValue: "#FFFFFF",
+      control: "color",
+    },
   },
 };
 

--- a/src/stories/ChakraInput.stories.tsx
+++ b/src/stories/ChakraInput.stories.tsx
@@ -1,0 +1,22 @@
+import ChakraInput from "@base/ChakraInput";
+
+export default {
+  title: "Component/ChakraInput",
+  component: ChakraInput,
+  argTypes: {
+    text: { defaultValue: "placeholder부분입니다", control: "text" },
+    size: { defaultValue: "lg", control: "text" },
+    width: {
+      defaultValue: 400,
+      control: { type: "range", min: 100, max: 640 },
+    },
+    type: {
+      defaultValue: "text",
+      control: "text",
+    },
+  },
+};
+
+export const Default = (args: any) => {
+  return <ChakraInput {...args}>Text</ChakraInput>;
+};


### PR DESCRIPTION
## 📌 기능 설명 
- ChakraInput 컴포넌트 생성
- 중복방지를 위해 Footer 컴포넌트에서 절대경로와 chakra-ui storybook addon 설정은 commit하지 않았습니다.

## 👩‍💻 요구 사항과 구현 내용 
- Header의 input, 로그인, 회원가입, 목표 생성 페이지에 들어가는 input 컴포넌트 생성
   - text: placeholder에 들어갈 문자열
   - size: chakra-ui에서 크기지정을 위해 md, lg 같은 문자열
   - width: 가로 길이 커스텀을 위한 숫자
   - type: text, password인 경우를 위한 문자열
   - variant: "outline" 이나 "filled" 사용을 위한 문자열
   - bgColor: variant-filled인 경우 색상을 변경하기 위한 문자열
      - hover하면 기본색상으로 변경되는 부분을 설정한 바탕색으로 적용하였습니다.
- Header의 input 컴포넌트
   - chakra-ui: input(filled-lg)
   - 가로 : 320px
   - 세로 : 48px
- 로그인, 회원가입에 들어가는 input 컴포넌트
   - chakra-ui : input(lg)
   - 가로 : 400px
   - 세로 : 48px
- 목표 생성 페이지에 들어가는 input 컴포넌트
   - chakra-ui : input(lg)
   - 가로 : 530px
   - 세로 : 48px

## 구현 결과
- storybook에서 스크린샷으로 가져왔습니다.
![image](https://user-images.githubusercontent.com/75886763/173614070-c116e183-ae39-4335-8c3b-47bfa58af84a.png)
