### PR TITLE
[Feat] CertificationButton 컴포넌트 추가

### DIFF
--- a/src/components/domain/ChallengePage/CertificationButton.tsx
+++ b/src/components/domain/ChallengePage/CertificationButton.tsx
@@ -2,17 +2,19 @@ import { Circle } from "@chakra-ui/react";
 import Icon from "@base/Icon";
 
 type CertificationButtonType = {
-  color?: "#FF7900" | "#D9D9D9";
+  bgColor?: "#FF7900" | "#D9D9D9";
   name?: "arrow-up" | "check";
+  color?: "#FFFFFF" | "#000000";
 };
 
 const ChallengeCertificationButton = ({
-  color = "#FF7900",
+  bgColor = "#FF7900",
   name = "arrow-up",
+  color = "#FFFFFF",
 }: CertificationButtonType) => {
   return (
-    <Circle size="115px" bg={color}>
-      <Icon name={name} />
+    <Circle size="115px" bg={bgColor}>
+      <Icon name={name} color={color} />
     </Circle>
   );
 };

--- a/src/components/domain/ChallengePage/CertificationButton.tsx
+++ b/src/components/domain/ChallengePage/CertificationButton.tsx
@@ -1,0 +1,20 @@
+import { Circle } from "@chakra-ui/react";
+import Icon from "@base/Icon";
+
+type CertificationButtonType = {
+  color?: "#FF7900" | "#D9D9D9";
+  name?: "arrow-up" | "check";
+};
+
+const ChallengeCertificationButton = ({
+  color = "#FF7900",
+  name = "arrow-up",
+}: CertificationButtonType) => {
+  return (
+    <Circle size="115px" bg={color}>
+      <Icon name={name} />
+    </Circle>
+  );
+};
+
+export default ChallengeCertificationButton;

--- a/src/stories/domain/ChallengePage/CertificationButton.stories.tsx
+++ b/src/stories/domain/ChallengePage/CertificationButton.stories.tsx
@@ -9,7 +9,11 @@ export const Default = () => {
   return (
     <>
       <CertificationButton></CertificationButton>
-      <CertificationButton color="#D9D9D9" name="check"></CertificationButton>
+      <CertificationButton
+        bgColor="#D9D9D9"
+        name="check"
+        color="#000000"
+      ></CertificationButton>
     </>
   );
 };

--- a/src/stories/domain/ChallengePage/CertificationButton.stories.tsx
+++ b/src/stories/domain/ChallengePage/CertificationButton.stories.tsx
@@ -1,0 +1,15 @@
+import CertificationButton from "@domain/ChallengePage/CertificationButton";
+
+export default {
+  title: "Domain/ChallengePage/CertificationButton",
+  component: CertificationButton,
+};
+
+export const Default = () => {
+  return (
+    <>
+      <CertificationButton></CertificationButton>
+      <CertificationButton color="#D9D9D9" name="check"></CertificationButton>
+    </>
+  );
+};


### PR DESCRIPTION
## 📌 기능 설명 
- Challenge Page의 ChallengeCertification 버튼
   - 115px * 115px
   - 정확한 원
   - 색상 : #FF7900 (대표색상)
   - feather-icon 들어감
      - 38px * 38px
      - 인증 전 : arrow-up
      - 인증 후 : check

## 👩‍💻 요구 사항과 구현 내용 
- Chakra-ui의 layout 도구를 사용하였습니다.
   - Circle
- prop 내용
   - bgColor?: "#FF7900" | "#D9D9D9"
      - 활성화 | 비활성화
   - name?: "arrow-up" | "check"
      - Icon 컴포넌트 재사용
   - color?: "#FFFFFF" | "#000000"
      - 활성화 | 비활성화

## 구현 결과
![image](https://user-images.githubusercontent.com/75886763/173786992-62aff8b1-27bb-403c-a702-6897b7f2a6d9.png)
