### PR TITLE
[토큰] localStorage 로직 수정

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -12,7 +12,7 @@ instance.interceptors.request.use((config) => {
   }
   const token = loadTokenFromLocalStorage();
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = `bearer ${token}`;
   }
   return config;
 });

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -3,13 +3,10 @@ const storage = window.localStorage;
 const TOKEN_KEY = "token";
 
 export const saveTokenToLocalStorage = (token: string) => {
-  return storage.setItem(TOKEN_KEY, JSON.stringify(token));
+  return storage.setItem(TOKEN_KEY, token);
 };
 
 export const loadTokenFromLocalStorage = (): string | null => {
   const token = storage.getItem(TOKEN_KEY);
-  if (token) {
-    return JSON.parse(token);
-  }
-  return null;
+  return token;
 };


### PR DESCRIPTION

## 📌 기능 설명 

토크은 원래 문자열이기 때문에 JSON.stringify없이 저장, 로드합니다.

## 👩‍💻 요구 사항과 구현 내용 

## 구현 결과
