### PR TITLE
[Feat] 목표 생성 페이지 API 연결

### DIFF
--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -12,11 +12,13 @@ export const fetchPostPostByChannelId = ({
   channelId,
 }: {
   title: string;
-  image?: string;
+  image?: string | null;
   channelId: string;
 }) =>
   axios.post("/posts/create", {
-    data: { title, image, channelId },
+    title,
+    image,
+    channelId,
   });
 
 export const fetchGetPostByPostId = (postId: string) =>

--- a/src/components/base/ChakraInput.tsx
+++ b/src/components/base/ChakraInput.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { Input } from "@chakra-ui/react";
-import React, { useEffect, useState } from "react";
+import { useState } from "react";
 
 type inputTypes = {
   placeholder: string;

--- a/src/components/domain/CreateChallengePage/ChallengeChannelRadio.tsx
+++ b/src/components/domain/CreateChallengePage/ChallengeChannelRadio.tsx
@@ -4,6 +4,7 @@ import { Box, HStack, Text, useRadio, useRadioGroup } from "@chakra-ui/react";
 
 type ChallengeChannelRadioType = {
   onChangeValue?: any;
+  channelList?: any;
 };
 
 function RadioCard(props: any) {
@@ -34,11 +35,12 @@ function RadioCard(props: any) {
 
 const ChallengeChannelRadio = ({
   onChangeValue,
+  channelList,
 }: ChallengeChannelRadioType) => {
-  const channels = ["운동", "독서", "공부", "루틴", "자기계발"];
+  const channels = channelList;
   const { getRootProps, getRadioProps } = useRadioGroup({
     name: "channel",
-    defaultValue: "운동",
+    defaultValue: channels[0],
     onChange: onChangeValue ? onChangeValue : console.log,
   });
 
@@ -46,14 +48,15 @@ const ChallengeChannelRadio = ({
 
   return (
     <HStack {...group} spacing="20px">
-      {channels.map((channelName) => {
-        const radio = getRadioProps({ value: channelName });
-        return (
-          <RadioCard key={channelName} {...radio}>
-            <Text fontSize="lg">{channelName}</Text>
-          </RadioCard>
-        );
-      })}
+      {channels &&
+        channels.map((channelName: any) => {
+          const radio = getRadioProps({ value: channelName });
+          return (
+            <RadioCard key={channelName} {...radio}>
+              <Text fontSize="lg">{channelName}</Text>
+            </RadioCard>
+          );
+        })}
     </HStack>
   );
 };

--- a/src/components/domain/CreateChallengePage/StartDateCalendar.tsx
+++ b/src/components/domain/CreateChallengePage/StartDateCalendar.tsx
@@ -28,6 +28,7 @@ const StartDateCalendar = ({ onChangeValue }: StartDateCalendarProps) => {
       showPopperArrow={false}
       customInput={
         <Input
+          isReadOnly={true}
           placeholder="시작일을 선택해주세요 \(*°▽°*)/"
           variant="outline"
           width="100%"

--- a/src/hooks/quries/useGetChannelList.ts
+++ b/src/hooks/quries/useGetChannelList.ts
@@ -1,0 +1,8 @@
+import { useQuery } from "react-query";
+import { fetchGetChannels } from "@api/channel";
+
+const useGetChannelList = () => {
+  return useQuery(["channelList"], fetchGetChannels);
+};
+
+export default useGetChannelList;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,22 +48,7 @@ export interface Post {
   _id: string;
   image?: string;
   imagePublicId?: string;
-  title: {
-    challengeTitle: string; // Challenge 제목
-    reward: string; // 보상 내용
-    days: [
-      // 잔디 (ChallengeTable에 이용)
-      {
-        day: 0;
-        isChecked: boolean;
-      },
-      {
-        day: 1;
-        isChecked: boolean;
-      }
-    ];
-    startDate: string; // 시작일 2022-06-23
-  };
+  title: string;
   channel: Channel;
   author: User;
   createdAt: string;


### PR DESCRIPTION
## 📌 기능 설명
- 목표 생성 페이지 API

## 👩‍💻 요구 사항과 구현 내용 
- 입력 폼 모두 작성해야 Button 활성화
- 생성 성공시 `/my/profile`로 넘어가기
- 실패시 alert 반영
- datepicker 입력폼 readonly로 변경
