### PR TITLE
[Feat] 응원하기, 댓글 알림 API 적용

### DIFF
--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -4,3 +4,21 @@ export const fetchGetNotificationList = () => axios.get("/notifications");
 
 export const fetchGetSeenMyNotification = () =>
   axios.get("/notifications/seen");
+
+export const fetchPostNotification = ({
+  notificationType,
+  notificationTypeId,
+  userId,
+  postId,
+}: {
+  notificationType: string;
+  notificationTypeId: string;
+  userId: string;
+  postId?: string | null;
+}) =>
+  axios.post("/notifications/create", {
+    notificationType,
+    notificationTypeId,
+    userId,
+    postId,
+  });

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -11,10 +11,10 @@ export const fetchPostNotification = ({
   userId,
   postId,
 }: {
-  notificationType: string;
+  notificationType: "COMMENT" | "FOLLOW" | "LIKE" | "MESSAGE";
   notificationTypeId: string;
   userId: string;
-  postId?: string | null;
+  postId: string | null;
 }) =>
   axios.post("/notifications/create", {
     notificationType,

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -14,7 +14,7 @@ export const fetchPostNotification = ({
   notificationType: "COMMENT" | "FOLLOW" | "LIKE" | "MESSAGE";
   notificationTypeId: string;
   userId: string;
-  postId: string | null;
+  postId?: string | null;
 }) =>
   axios.post("/notifications/create", {
     notificationType,

--- a/src/pages/ChallengePage.tsx
+++ b/src/pages/ChallengePage.tsx
@@ -15,6 +15,7 @@ import CertificationTable from "@domain/ChallengePage/CertificationTable";
 import CertificationButton from "@domain/ChallengePage/CertificationButton";
 import usePageTitle from "@hooks/usePageTitle";
 import useGetChallenge from "@hooks/quries/useGetChallenge";
+import { fetchPostNotification } from "@api/notification";
 
 const ChallengePage = () => {
   const [myUser] = useAtom(userAtom);
@@ -91,6 +92,7 @@ const ChallengePage = () => {
     setCheerUpCount(cheerUpCount + 1);
     setIsCheered(true);
     setCheerUpId(cheerUpId);
+    void onCheerUpNotificationEvent(cheerUpId);
   };
 
   const setCheerUpNo = () => {
@@ -100,13 +102,26 @@ const ChallengePage = () => {
   };
 
   const onCheerUpEvent = async () => {
-    if (isCheered) {
+    if (!myUser._id) {
+      alert("로그인 후 이용가능합니다.");
+    } else if (isCheered) {
       const { status } = await fetchDeleteLikeByPostId(cheerUpId);
       status === 200 ? setCheerUpNo() : alert("다시 시도바랍니다.");
     } else {
       const { data, status } = await fetchPostLikeByPostId(postId);
       status === 200 ? setCheerUpYes(data._id) : alert("다시 시도바랍니다.");
     }
+  };
+
+  const onCheerUpNotificationEvent = async (cheerUpId) => {
+    const { status } = await fetchPostNotification({
+      notificationType: "LIKE",
+      notificationTypeId: cheerUpId,
+      userId: myUser._id,
+    });
+    status === 200
+      ? console.log("success like-notification")
+      : console.log("fail like-notification");
   };
 
   const onCertificationEvent = async () => {

--- a/src/pages/ChallengePage.tsx
+++ b/src/pages/ChallengePage.tsx
@@ -102,7 +102,7 @@ const ChallengePage = () => {
   };
 
   const onCheerUpEvent = async () => {
-    if (!myUser._id) {
+    if (myUser) {
       alert("로그인 후 이용가능합니다.");
     } else if (isCheered) {
       const { status } = await fetchDeleteLikeByPostId(cheerUpId);


### PR DESCRIPTION
## 📌 기능 설명
- 목표 상세 페이지에서 응원하기 알림 API 적용
- 목표 댓글 페이지에서 댓글생성 알림 API 적용

## 👩‍💻 요구 사항과 구현 내용 
- 목표 상세 페이지
   - 비회원은 응원하기 불가능 처리
   - 절차 : 응원하기 API → 응답받기 → 응원._id 로 알림 API
- 목표 댓글 페이지
   - 비회원인 경우 입력창 안보이게 처리
   - 절차: 댓글생성 API → 응답받기 → 댓글._id 로 알림 API