### PR TITLE
[Feat] 알림 페이지 시간 추가, 알림 보낸 사용자 프로필 이미지 보이게 수정

### DIFF
--- a/src/components/domain/NotificationPage/Notification.tsx
+++ b/src/components/domain/NotificationPage/Notification.tsx
@@ -1,32 +1,51 @@
 import { Flex, Avatar, Text } from "@chakra-ui/react";
+import styled from "@emotion/styled";
 
-type NotificationType = {
+interface NotificationProps {
   avatarSrc: string;
   userName: string;
-  alarmType: "follow" | "comment" | "cheer";
-};
+  notificationType: "follow" | "comment" | "like";
+  createdAt: string;
+}
 
-const Notification = ({ avatarSrc, userName, alarmType }: NotificationType) => {
+const CardContainer = styled(Flex)`
+  height: 96px;
+  padding: 0 16px;
+  background-color: white;
+`;
+
+const UserNameText = styled.span`
+  font-weight: bold;
+`;
+
+const Notification = ({
+  avatarSrc,
+  userName,
+  notificationType,
+  createdAt,
+}: NotificationProps) => {
+  const notifiedTime = new Date(createdAt).toLocaleString().slice(2, 20);
+
   return (
-    <Flex
-      w="100%"
-      h="96px"
-      padding="0 16px"
-      alignItems="center"
-      bg="#ffffff"
-      flexShrink={0}
-    >
+    <CardContainer alignItems="center">
       <Avatar size="lg" src={avatarSrc} marginRight="16px" />
-      <Text fontSize={"lg"}>
-        <span style={{ fontWeight: "bold" }}>{userName}</span>
-        님이
-        {alarmType === "follow"
-          ? " 나를 팔로우했어요 😊"
-          : alarmType === "comment"
-          ? " 댓글을 남겼어요 🪧"
-          : " 나를 응원했어요 🎉"}
-      </Text>
-    </Flex>
+      <div>
+        <Flex>
+          <UserNameText>{userName}</UserNameText>
+          <Text>
+            님이
+            {notificationType === "follow"
+              ? " 나를 팔로우했어요 😊"
+              : notificationType === "comment"
+              ? " 댓글을 남겼어요 🪧"
+              : " 나를 응원했어요 🎉"}
+          </Text>
+        </Flex>
+        <Text fontSize="sm" marginTop={2}>
+          {notifiedTime}
+        </Text>
+      </div>
+    </CardContainer>
   );
 };
 

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -1,4 +1,4 @@
-import { Notification } from "src/types";
+import { Notification, User } from "src/types";
 import NotificationCard from "@domain/NotificationPage/Notification";
 import { Flex } from "@chakra-ui/react";
 import DefaultText from "@base/DefaultText";
@@ -20,15 +20,16 @@ const NotificationPage = () => {
           return (
             <NotificationCard
               key={notification._id}
-              alarmType={
+              notificationType={
                 notification.follow
                   ? "follow"
                   : notification.comment
                   ? "comment"
-                  : "cheer"
+                  : "like"
               }
-              avatarSrc=""
+              avatarSrc={notification.author.image}
               userName={notification.author.fullName}
+              createdAt={notification.createdAt}
             ></NotificationCard>
           );
         })

--- a/src/stories/domain/NotificationPage.stories.tsx/Notification.stories.tsx
+++ b/src/stories/domain/NotificationPage.stories.tsx/Notification.stories.tsx
@@ -8,9 +8,24 @@ export default {
 export const Default = () => {
   return (
     <Flex w="610px" height="100vh" flexDirection="column">
-      <Notification avatarSrc="" userName="사용자1" alarmType="follow" />
-      <Notification avatarSrc="" userName="사용자1" alarmType="comment" />
-      <Notification avatarSrc="" userName="사용자1" alarmType="cheer" />
+      <Notification
+        avatarSrc=""
+        userName="사용자1"
+        notificationType="follow"
+        createdAt=""
+      />
+      <Notification
+        avatarSrc=""
+        userName="사용자1"
+        notificationType="comment"
+        createdAt=""
+      />
+      <Notification
+        avatarSrc=""
+        userName="사용자1"
+        notificationType="like"
+        createdAt=""
+      />
     </Flex>
   );
 };


### PR DESCRIPTION
# PR 템플릿(이 부분은 지우고 사용해주세요)
알림 페이지 시간 추가, 알림 보낸 사용자 프로필 이미지 보이게 수정

## 👩‍💻 요구 사항과 구현 내용 
알림 페이지에서 알림을 보낸 사람의 프로필 이미지를 Avatar에 넣고 시간을 표시했습니다. 모바일 화면도 고려해서 폰트 크기를 좀 줄였는데 보고 의견 남겨주시면 감사하겠씁니다

## 구현 결과
<img width="1440" alt="스크린샷 2022-06-29 16 48 11" src="https://user-images.githubusercontent.com/81501723/176382691-a7c93c58-7c8f-4724-a026-93db2ccca870.png">
<img width="1440" alt="스크린샷 2022-06-29 16 48 17" src="https://user-images.githubusercontent.com/81501723/176382733-d94a583d-b4a3-4dd3-9c67-1f9245c97ea0.png">

