### PR TITLE
[Fix] 채널 페이지 pathname에 따른 렌더링

### DIFF
--- a/src/components/domain/ChallengesPage/Chips.tsx
+++ b/src/components/domain/ChallengesPage/Chips.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@chakra-ui/react";
 import styled from "@emotion/styled";
-import { useState } from "react";
 
 interface ChipsProps {
   names: string[];
-  setChannelName: React.Dispatch<React.SetStateAction<string>>;
+  selectedChip: string;
+  onClickProp: React.MouseEventHandler;
 }
 
 const ChipsContainer = styled.div`
@@ -25,23 +25,19 @@ const Chip = styled(Button)`
   }
 `;
 
-const Chips = ({ names, setChannelName }: ChipsProps) => {
-  const [selectedChannelIndex, setSelectedChannelIndex] = useState(0);
-
+const Chips = ({ names, selectedChip, onClickProp }: ChipsProps) => {
   return (
     <ChipsContainer>
       {names.length !== 0 &&
-        names.map((name, index) => (
+        names.map((name) => (
           <Chip
             key={name}
-            onClick={() => {
-              setChannelName(name);
-              setSelectedChannelIndex(index);
-            }}
+            data-description={name}
             style={{
-              color: selectedChannelIndex === index ? "white" : "#838489",
-              backgroundColor: selectedChannelIndex === index ? "#ff7900" : "",
+              color: selectedChip === name ? "white" : "#838489",
+              backgroundColor: selectedChip === name ? "#ff7900" : "",
             }}
+            onClick={onClickProp}
           >
             {name}
           </Chip>

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -23,7 +23,7 @@ const Footer = ({ user }: Props) => {
           <ChakraText size="md">홈</ChakraText>
         </Flex>
       </Link>
-      <Link to="/challenges/62b1edf52952ee4508c8a068">
+      <Link to="/challenges/62b017b6700a302ecbfca608">
         <Flex
           flexDirection="column"
           alignItems="center"

--- a/src/pages/ChallengesPage.tsx
+++ b/src/pages/ChallengesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Channel, Post } from "src/types";
-import { fetchGetChannelByName, fetchGetChannels } from "@api/channel";
+import { fetchGetChannels } from "@api/channel";
 import { fetchGetPostListByChannel } from "@api/post";
 import usePageTitle from "@hooks/usePageTitle";
 import Chips from "@domain/ChallengesPage/Chips";
@@ -28,6 +28,10 @@ const ChallengesPage = () => {
         alert("다시 시도바랍니다!");
       }
     })();
+    window.addEventListener("popstate", windowListener);
+    return () => {
+      window.removeEventListener("popstate", windowListener);
+    };
   }, []);
 
   useEffect(() => {
@@ -37,8 +41,13 @@ const ChallengesPage = () => {
         const { data, status } = await fetchGetPostListByChannel(
           selectedChannelId
         );
-        if (status === 200) setChallenges(data);
-        else alert("다시 시도바랍니다!");
+        if (status === 200) {
+          setChallenges(data);
+          const clickedChannel = channels.filter(
+            (item) => item._id === selectedChannelId
+          )[0];
+          setSelectedChannel(clickedChannel);
+        } else alert("다시 시도바랍니다!");
       })();
     }
     setShow(true);
@@ -46,13 +55,16 @@ const ChallengesPage = () => {
 
   const onClickChips = (event) => {
     const channelDescription = event.target.dataset.description;
-    const clickedChannel = channels.filter(
+    const { _id } = channels.filter(
       (item) => item.description === channelDescription
     )[0];
-    setSelectedChannelId(clickedChannel._id);
-    setSelectedChannel(clickedChannel);
-    const path = `/challenges/${clickedChannel._id}`;
-    history.pushState(null, null, path);
+    setSelectedChannelId(_id);
+    history.pushState(null, null, `/challenges/${_id}`);
+  };
+
+  const windowListener = () => {
+    const clickedChannel = window.location.pathname.split("/")[2];
+    setSelectedChannelId(clickedChannel);
   };
 
   return (


### PR DESCRIPTION
## 📌 기능 설명
- pathname에 따른 렌더링
   - 라디오 버튼`chips` 선택 렌더링
   - 채널에 맞는 challenge 목록 렌더링
- 뒤로가기시 pathname에 알맞게 렌더링
   - 라디오 버튼`chips` 선택 렌더링 (상동)
   - 채널에 맞는 challenge 목록 렌더링 (상동)

## 👩‍💻 요구 사항과 구현 내용 
- 채널 페이지 unmount시 윈도우 이벤트 제거 구현
- channelId가 변경될 때마다 라디오 버튼, challenge 목록 변동되도록 구현

## 회의 후 참고사항
- window의 이벤트로 pushstate, popstate하는 것보다 react-router-dom을 이용하여 코드 개선