### PR TITLE
[Refactor] React-query 적용

### DIFF
--- a/src/api/channel.ts
+++ b/src/api/channel.ts
@@ -2,7 +2,11 @@ import axios from "@lib/axios";
 import { AxiosResponse } from "axios";
 import { Channel } from "src/types";
 
-export const fetchGetChannels = () => axios.get("/channels");
+export const fetchGetChannels = async () => {
+  const { data } = await axios.get<Channel[]>("/channels");
+
+  return data;
+};
 
 export const fetchGetChannelByName = (
   channelName: string

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -1,7 +1,11 @@
 import axios from "@lib/axios";
+import { Post } from "src/types";
 
-export const fetchGetPostListByChannel = (channelId: string) =>
-  axios.get(`/posts/channel/${channelId}`);
+export const fetchGetPostListByChannel = async (channelId: string) => {
+  const { data } = await axios.get<Post[]>(`/posts/channel/${channelId}`);
+
+  return data;
+};
 
 export const fetchGetUserPostList = (authorId: string) =>
   axios.get(`/posts/author/${authorId}`);

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,11 +1,15 @@
 import axios from "@lib/axios";
+import { User } from "src/types";
 
 export const fetchGetUserList = () => axios.get("/users/get-users");
 
 export const fetchGetOnlineUserList = () => axios.get("/users/online-users");
 
-export const fetchGetUserById = (userId: string) =>
-  axios.get(`/users/${userId}`);
+export const fetchGetUserById = async (userId: string) => {
+  const { data } = await axios.get<User>(`/users/${userId}`);
+
+  return data;
+};
 
 export const fetchGetFollowUserList = async (followUserIdList: string[]) => {
   return await Promise.all(

--- a/src/components/Router/index.tsx
+++ b/src/components/Router/index.tsx
@@ -30,7 +30,7 @@ const AppRouter = () => {
         <Route element={<InputLayout />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/search" element={<SearchUserPage />} />
-          <Route path="/profile/:username" element={<OtherProfilePage />} />
+          <Route path="/profile/:userId" element={<OtherProfilePage />} />
           <Route path="/*" element={<NotFoundPage />} />
         </Route>
 

--- a/src/components/domain/FollowPage/FollowPageTab.tsx
+++ b/src/components/domain/FollowPage/FollowPageTab.tsx
@@ -14,23 +14,16 @@ import { useState } from "react";
 import Card from "@base/Card";
 import DefaultText from "@base/DefaultText";
 
-const TabsContainer = styled.div`
-  margin-top: 40px;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  border: none;
-  border-radius: 6px 0;
-`;
-
-type FollowPageProp = {
+interface Props {
   followingList: User[];
   followersList: User[];
-};
+}
 
-const FollowPageTab = ({ followingList, followersList }: FollowPageProp) => {
+const FollowPageTab = ({ followingList, followersList }: Props) => {
   const [selectedTab, setSelectedTab] = useState(0);
   const navigate = useNavigate();
-  const handleClickUser = (userId: string): void => {
-    navigate(`/profile/${userId}`);
+  const handleClickUser = (userId: string) => {
+    navigate(`/profile/${userId}`, { state: userId });
   };
 
   return (
@@ -47,7 +40,7 @@ const FollowPageTab = ({ followingList, followersList }: FollowPageProp) => {
             }}
             onClick={() => setSelectedTab(0)}
           >
-            팔로우
+            팔로워
           </Tab>
           <Tab
             fontSize={24}
@@ -59,28 +52,26 @@ const FollowPageTab = ({ followingList, followersList }: FollowPageProp) => {
             }}
             onClick={() => setSelectedTab(1)}
           >
-            팔로워
+            팔로잉
           </Tab>
         </TabList>
         <TabPanels style={{ backgroundColor: "white" }}>
           <TabPanel>
             {followingList.length ? (
               <Flex flexDirection="column">
-                {followingList.map((user) => {
-                  return (
-                    <Card
-                      type="user"
-                      heading={user.fullName}
-                      text={user.coverImage ?? "자기소개 없음"}
-                      avatarSrc={user.image}
-                      styleProps={{ boxShadow: "none" }}
-                      onClick={() => {
-                        handleClickUser(user._id);
-                      }}
-                      key={user._id}
-                    ></Card>
-                  );
-                })}
+                {followingList.map((user) => (
+                  <Card
+                    type="user"
+                    heading={user.fullName}
+                    text={user.coverImage ?? "자기소개 없음"}
+                    avatarSrc={user.image}
+                    styleProps={{ boxShadow: "none" }}
+                    onClick={() => {
+                      handleClickUser(user._id);
+                    }}
+                    key={user._id}
+                  ></Card>
+                ))}
               </Flex>
             ) : (
               <DefaultText>아직 팔로잉이 없어요!</DefaultText>
@@ -115,3 +106,10 @@ const FollowPageTab = ({ followingList, followersList }: FollowPageProp) => {
 };
 
 export default FollowPageTab;
+
+const TabsContainer = styled.div`
+  margin-top: 40px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border: none;
+  border-radius: 6px 0;
+`;

--- a/src/components/domain/FollowPage/FollowPageTab.tsx
+++ b/src/components/domain/FollowPage/FollowPageTab.tsx
@@ -23,7 +23,7 @@ const FollowPageTab = ({ followingList, followersList }: Props) => {
   const [selectedTab, setSelectedTab] = useState(0);
   const navigate = useNavigate();
   const handleClickUser = (userId: string) => {
-    navigate(`/profile/${userId}`, { state: userId });
+    navigate(`/profile/${userId}`);
   };
 
   return (

--- a/src/hooks/quries/useChallenges.ts
+++ b/src/hooks/quries/useChallenges.ts
@@ -1,0 +1,10 @@
+import { fetchGetPostListByChannel } from "@api/post";
+import { useQuery } from "react-query";
+
+const useChallenges = (channelId: string) => {
+  return useQuery(["challenges", channelId], () =>
+    fetchGetPostListByChannel(channelId)
+  );
+};
+
+export default useChallenges;

--- a/src/hooks/quries/useChannels.ts
+++ b/src/hooks/quries/useChannels.ts
@@ -1,0 +1,8 @@
+import { fetchGetChannels } from "@api/channel";
+import { useQuery } from "react-query";
+
+const useChannels = () => {
+  return useQuery("channels", fetchGetChannels);
+};
+
+export default useChannels;

--- a/src/hooks/quries/useGetUser.ts
+++ b/src/hooks/quries/useGetUser.ts
@@ -1,8 +1,11 @@
 import { useQuery } from "react-query";
 import { fetchGetUserById } from "@api/user";
+import { User } from "src/types";
 
 const useGetUserById = (userId: string) => {
-  return useQuery(["user", userId], () => fetchGetUserById(userId));
+  return useQuery<User, Error>(["user", userId], () =>
+    fetchGetUserById(userId)
+  );
 };
 
 export default useGetUserById;

--- a/src/pages/ChallengesPage.tsx
+++ b/src/pages/ChallengesPage.tsx
@@ -1,56 +1,46 @@
 import { useEffect, useState } from "react";
 import { Channel, Post } from "src/types";
-import { fetchGetChannels } from "@api/channel";
-import { fetchGetPostListByChannel } from "@api/post";
 import usePageTitle from "@hooks/usePageTitle";
 import Chips from "@domain/ChallengesPage/Chips";
 import Challenges from "@domain/ChallengesPage/Challenges";
+import useChannels from "@hooks/quries/useChannels";
+import useChallenges from "@hooks/quries/useChallenges";
 
 const ChallengesPage = () => {
   usePageTitle("채널");
   const [selectedChannelId, setSelectedChannelId] = useState(
     window.location.pathname.split("/")[2]
   );
+  const { data: channelsData } = useChannels();
+  const { data: challengesData } = useChallenges(selectedChannelId);
   const [channels, setChannels] = useState<Channel[]>(); // 채널 목록 데이터전체
   const [challenges, setChallenges] = useState<Post[]>(); // 선택된 채널의 포스트 목록
   const [selectedChannel, setSelectedChannel] = useState<Channel>(); // 선택된 채널 데이터전체
-  const [show, setShow] = useState(false);
+
+  const windowListener = () => {
+    const clickedChannel = window.location.pathname.split("/")[2];
+    setSelectedChannelId(clickedChannel);
+  };
 
   useEffect(() => {
-    void (async () => {
-      const { data, status } = await fetchGetChannels();
-      if (status === 200) {
-        setChannels(data);
-        setSelectedChannel(
-          data.filter((item) => item._id === selectedChannelId)[0]
-        );
-      } else {
-        alert("다시 시도바랍니다!");
-      }
-    })();
+    setChannels(channelsData);
+
     window.addEventListener("popstate", windowListener);
     return () => {
       window.removeEventListener("popstate", windowListener);
     };
-  }, []);
+  }, [channelsData]);
 
   useEffect(() => {
-    if (selectedChannelId) {
-      setShow(false);
-      void (async () => {
-        const { data, status } = await fetchGetPostListByChannel(
-          selectedChannelId
-        );
-        if (status === 200) {
-          setChallenges(data);
-          const clickedChannel = channels.filter(
-            (item) => item._id === selectedChannelId
-          )[0];
-          setSelectedChannel(clickedChannel);
-        } else alert("다시 시도바랍니다!");
-      })();
-    }
-    setShow(true);
+    setChallenges(challengesData);
+  }, [challengesData]);
+
+  useEffect(() => {
+    setChallenges(challengesData);
+    const clickedChannel = channels?.filter(
+      (item) => item._id === selectedChannelId
+    )[0];
+    setSelectedChannel(clickedChannel);
   }, [selectedChannelId]);
 
   const onClickChips = (event) => {
@@ -62,23 +52,14 @@ const ChallengesPage = () => {
     history.pushState(null, null, `/challenges/${_id}`);
   };
 
-  const windowListener = () => {
-    const clickedChannel = window.location.pathname.split("/")[2];
-    setSelectedChannelId(clickedChannel);
-  };
-
   return (
     <>
-      {show && (
-        <>
-          <Chips
-            names={(channels || []).map((challenge) => challenge.description)}
-            selectedChip={selectedChannel?.description}
-            onClickProp={onClickChips}
-          />
-          <Challenges posts={challenges || []} />
-        </>
-      )}
+      <Chips
+        names={(channels || []).map((challenge) => challenge.description)}
+        selectedChip={selectedChannel?.description || "독서"}
+        onClickProp={onClickChips}
+      />
+      <Challenges posts={challenges || []} />
     </>
   );
 };

--- a/src/pages/CreateChallengePage.tsx
+++ b/src/pages/CreateChallengePage.tsx
@@ -24,14 +24,14 @@ const CreateChallengePage = () => {
 
   const { data: channelList } = useGetChannelList();
   useEffect(() => {
-    setChannel(channelList?.data[0]._id);
+    setChannel(channelList?.[0]._id);
   }, [channelList]);
 
   const onChallengeTitleChange = (newChallengeTitle: string) => {
     setChallengeTitle(newChallengeTitle.trim());
   };
   const onChannelChange = (newChannel: string) => {
-    const channelId = channelList.data.filter(({ description }: any) => {
+    const channelId = channelList.filter(({ description }) => {
       return description === newChannel;
     })[0]._id;
     setChannel(channelId);
@@ -61,8 +61,16 @@ const CreateChallengePage = () => {
     }
   };
 
-  const submitChallengeForm = async (newChallenge: any) => {
-    const { status }: any = await fetchPostPostByChannelId({
+  const submitChallengeForm = async (newChallenge: {
+    challengeTitle: string;
+    reward: string;
+    days: {
+      day: number;
+      isChecked: boolean;
+    }[];
+    startDate: string;
+  }) => {
+    const { status } = await fetchPostPostByChannelId({
       title: JSON.stringify(newChallenge),
       image: null,
       channelId: channel,
@@ -98,7 +106,7 @@ const CreateChallengePage = () => {
         {channelList && (
           <ChallengeChannelRadio
             onChangeValue={onChannelChange}
-            channelList={channelList.data.map((channel: any) => {
+            channelList={channelList.map((channel) => {
               return channel.description;
             })}
           />

--- a/src/pages/FollowPage.tsx
+++ b/src/pages/FollowPage.tsx
@@ -7,14 +7,15 @@ import useGetUserById from "@hooks/quries/useGetUser";
 import { useParams } from "react-router-dom";
 
 const FollowPage = () => {
-  //const [user] = useAtom(userAtom);
-
   const { userId } = useParams();
-  const { data: userRes } = useGetUserById(userId);
-
-  const [user, setUser] = useState<User>({} as User);
+  const { data: userData } = useGetUserById(userId);
+  const [user, setUser] = useState<User>();
   const [followerList, setFollowerList] = useState<User[]>([]);
   const [followingList, setFollowingList] = useState<User[]>([]);
+
+  useEffect(() => {
+    setUser(userData);
+  }, [userData]);
 
   const followerIdList: string[] =
     user?.followers?.map((follow) => follow.follower) ?? [];
@@ -26,22 +27,16 @@ const FollowPage = () => {
   const { data: followingResList } = useGetFollowUserList(followingIdList);
 
   useEffect(() => {
-    if (userRes) {
-      setUser(userRes.data);
-    }
-  }, [userRes]);
-
-  useEffect(() => {
     if (followerResList) {
-      setFollowerList(followerResList.map((res) => res.data));
+      setFollowerList(followerResList);
     }
-  }, [userRes, followerResList]);
+  }, [followerResList]);
 
   useEffect(() => {
     if (followingResList) {
-      setFollowingList(followingResList.map((res) => res.data));
+      setFollowingList(followingResList);
     }
-  }, [userRes, followingResList]);
+  }, [followingResList]);
 
   return (
     <PageTab

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage = () => {
 
   useEffect(() => {
     if (data) {
-      setChannelsList(data.data as Array<Channel>);
+      setChannelsList(data);
     }
   }, [data]);
 
@@ -32,7 +32,7 @@ const HomePage = () => {
 
   useEffect(() => {
     if (res) {
-      setPostLists(res.map((r) => r.data));
+      setPostLists(res);
     }
   }, [res]);
 

--- a/src/pages/OtherProfilePage.tsx
+++ b/src/pages/OtherProfilePage.tsx
@@ -1,6 +1,6 @@
 import UserAvatar from "@domain/ProfilePage/UserAvatar";
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { User } from "src/types";
 import OtherSummary from "@domain/ProfilePage/OtherSummary";
 import OtherChallenges from "@domain/ProfilePage/OtherChallenges";
@@ -8,8 +8,7 @@ import { Flex } from "@chakra-ui/react";
 import useGetUserById from "@hooks/quries/useGetUser";
 
 const OtherProfilePage = () => {
-  const location = useLocation();
-  const userId = location.state as string;
+  const { userId } = useParams();
   const { data } = useGetUserById(userId);
   const [user, setUser] = useState<User>();
 

--- a/src/pages/OtherProfilePage.tsx
+++ b/src/pages/OtherProfilePage.tsx
@@ -1,4 +1,3 @@
-import { fetchGetUserById } from "@api/user";
 import UserAvatar from "@domain/ProfilePage/UserAvatar";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";

--- a/src/pages/OtherProfilePage.tsx
+++ b/src/pages/OtherProfilePage.tsx
@@ -1,38 +1,27 @@
 import { fetchGetUserById } from "@api/user";
 import UserAvatar from "@domain/ProfilePage/UserAvatar";
-import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { User } from "src/types";
 import OtherSummary from "@domain/ProfilePage/OtherSummary";
 import OtherChallenges from "@domain/ProfilePage/OtherChallenges";
-
-const UserInfo = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-  margin-top: 32px;
-`;
+import { Flex } from "@chakra-ui/react";
+import useGetUserById from "@hooks/quries/useGetUser";
 
 const OtherProfilePage = () => {
   const location = useLocation();
   const userId = location.state as string;
+  const { data } = useGetUserById(userId);
   const [user, setUser] = useState<User>();
 
   useEffect(() => {
-    void (async () => {
-      const result = await fetchGetUserById(userId);
-      if (result.data) {
-        setUser(result.data);
-      }
-    })();
-  }, []);
+    setUser(data);
+  }, [data]);
 
   return (
     user && (
       <>
-        <UserInfo>
+        <Flex justifyContent="space-evenly" alignItems="center" marginTop={8}>
           <UserAvatar image={user.image} name={user.fullName} />
           <OtherSummary
             introduce={user.coverImage}
@@ -40,7 +29,7 @@ const OtherProfilePage = () => {
             followingCount={user.following.length}
             id={user._id}
           />
-        </UserInfo>
+        </Flex>
         <OtherChallenges challenges={user.posts} />
       </>
     )

--- a/src/pages/SearchUserPage.tsx
+++ b/src/pages/SearchUserPage.tsx
@@ -29,7 +29,7 @@ const SearchUserPage = () => {
   }
 
   const handleClickUserCard = (userId: string) => {
-    navigate(`/profile/${userId}`, { state: userId });
+    navigate(`/profile/${userId}`);
   };
 
   return (

--- a/src/pages/SearchUserPage.tsx
+++ b/src/pages/SearchUserPage.tsx
@@ -1,5 +1,5 @@
 import QueryString from "qs";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { User } from "src/types";
 import { Flex } from "@chakra-ui/react";


### PR DESCRIPTION
## 📌 기능 설명 
react query의 `useQuery`를 적용하지 못했거나 덜 적용했던 부분에 마저 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용 
useQuery의 인자로 전달되는 fetch 함수들을 data를 바로 리턴하면서 타입을 알 수 있도록 수정하고, 커스텀 훅을 이용하여 각 페이지에 필요한 데이터를 fetch할 수 있게 수정했습니다. ChallengesPage에서는 `selectedChip`이 "독서"라는 기본 값을 갖도록 추가했습니다. 그 외 불필요한 라인들을 제거했습니다. 그 외에 FollowPage에서 팔로워/팔로잉이 중복 가능하도록 되어 있어서 render 시 key가 겹쳐 warning이 일어나는데 이는 나중에 중복 제한 로직을 추가하면 제거될 거라 생각합니다.
## 구현 결과
