### PR TITLE
[Fix] 알림 API 자기 자신은 알림 보내지 않기

### DIFF
--- a/src/pages/ChallengePage.tsx
+++ b/src/pages/ChallengePage.tsx
@@ -130,6 +130,7 @@ const ChallengePage = () => {
   };
 
   const onCheerUpNotificationEvent = async (cheerUpId) => {
+    if (myUser._id === authorId) return;
     const { status } = await fetchPostNotification({
       notificationType: "LIKE",
       notificationTypeId: cheerUpId,

--- a/src/pages/CommentPage.tsx
+++ b/src/pages/CommentPage.tsx
@@ -41,6 +41,7 @@ const CommentPage = () => {
   }, [commentValue]);
 
   const onCommentNotificationEvent = async (commentId) => {
+    if (myUser._id === authorId) return;
     const { status } = await fetchPostNotification({
       notificationType: "COMMENT",
       notificationTypeId: commentId,


### PR DESCRIPTION
## 📌 기능 설명 
- 본인 게시글에서 본인이 작성한 댓글, 응원은 알림 안보내기

## 👩‍💻 요구 사항과 구현 내용 
- 게시글의 작성자id 와 현재 알림을 보내는 유저의 id를 비교하여 알림API 호출 여부 결정