### PR TITLE
[Fix] noImplicitAny true 설정, commentPage 아바타 클릭시 댓글 삭제 버그, comment 클릭 시 해당 유저페이지로 이동

### DIFF
--- a/src/components/base/Icon.tsx
+++ b/src/components/base/Icon.tsx
@@ -1,8 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import React from "react";
 import styled from "@emotion/styled";
 import { Buffer } from "buffer";
@@ -30,7 +26,11 @@ const Icon = ({ name, size = 38, color = "#000000" }: iconTypes) => {
 
   return (
     <IconWrapper>
-      <img src={`data:image/svg+xml;base64,${base64}`} alt={name} />
+      <img
+        src={`data:image/svg+xml;base64,${base64}`}
+        alt={name}
+        data-icon="icon"
+      />
     </IconWrapper>
   );
 };

--- a/src/components/domain/CommentPage/CommentCard.tsx
+++ b/src/components/domain/CommentPage/CommentCard.tsx
@@ -1,14 +1,31 @@
 import Icon from "@base/Icon";
 import { Avatar, Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
 
-const Comment = ({
+interface Prop {
+  isGuest: boolean;
+  avatarSrc: string | undefined;
+  commentAuthor: string;
+  commentAuthorId: string;
+  commentContent: string;
+  commentCreatedAt: string;
+}
+
+const CommentCard = ({
   isGuest = true,
   avatarSrc = undefined,
-  commentAuthor = "author.fullName",
-  commentContent = "Lorem ipsum dolor sit, amet consectetur",
-  commentCreatedAt = "2022-06-23 17:23",
-}) => {
+  commentAuthor,
+  commentAuthorId,
+  commentContent,
+  commentCreatedAt,
+}: Prop) => {
   const avatarSize = "md";
+  const navigate = useNavigate();
+
+  const onUserClick = (userId: string) => {
+    navigate(`/profile/${userId}`, { state: userId });
+  };
+
   return (
     <Flex
       padding="15px"
@@ -17,10 +34,25 @@ const Comment = ({
       boxShadow="0px 2px 4px rgba(0, 0, 0, 0.1)"
       gap="20px"
     >
-      <Avatar size={avatarSize} src={avatarSrc}></Avatar>
+      <Avatar
+        size={avatarSize}
+        src={avatarSrc}
+        onClick={() => {
+          onUserClick(commentAuthorId);
+        }}
+        _hover={{ cursor: "pointer" }}
+      ></Avatar>
       <Flex direction="column" w="100%" gap="10px">
         <Flex w="100%" justifyContent="space-between">
-          <Heading size="sm">{commentAuthor}</Heading>
+          <Heading
+            size="sm"
+            onClick={() => {
+              onUserClick(commentAuthorId);
+            }}
+            _hover={{ cursor: "pointer" }}
+          >
+            {commentAuthor}
+          </Heading>
           <Flex alignItems="flex-end" gap="5px">
             <Text fontSize="md" color="#838489">
               {commentCreatedAt}
@@ -42,4 +74,4 @@ const Comment = ({
   );
 };
 
-export default Comment;
+export default CommentCard;

--- a/src/pages/ChallengePage.tsx
+++ b/src/pages/ChallengePage.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-misused-promises */
-/* eslint-disable no-unsafe-optional-chaining */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Circle, Flex } from "@chakra-ui/react";
@@ -16,6 +14,7 @@ import CommentButton from "@domain/ChallengePage/CommentButton";
 import CheerUpButton from "@domain/ChallengePage/CheerUpButton";
 import CertificationTable from "@domain/ChallengePage/CertificationTable";
 import CertificationButton from "@domain/ChallengePage/CertificationButton";
+import { Like } from "src/types";
 
 const ChallengePage = () => {
   const [myUser] = useAtom(userAtom);
@@ -44,7 +43,7 @@ const ChallengePage = () => {
 
   useEffect(() => {
     if (Contents?.status === 200) {
-      const { author, title: Content, comments, likes } = Contents?.data;
+      const { author, title: Content, comments, likes } = Contents.data;
       const {
         days,
         reward,
@@ -78,7 +77,7 @@ const ChallengePage = () => {
     setShow(true);
   }, [presentDay]);
 
-  const validateGuest = (postUserId) => {
+  const validateGuest = (postUserId: string) => {
     if (myUser && myUser._id === postUserId) setIsGuest(false);
   };
   const validateDate = (calculatedPresentDay: number) => {
@@ -86,7 +85,7 @@ const ChallengePage = () => {
     if (calculatedPresentDay < 0) setPresentDay(0);
     if (29 < calculatedPresentDay) setPresentDay(30);
   };
-  const checkIsCheered = (cheerUpList) => {
+  const checkIsCheered = (cheerUpList: Like[]) => {
     const userCheerUp = cheerUpList.filter((cheerUpUser) => {
       return myUser && cheerUpUser.user === myUser._id;
     });
@@ -98,7 +97,7 @@ const ChallengePage = () => {
     }
   };
 
-  const setCheerUpYes = (cheerUpId) => {
+  const setCheerUpYes = (cheerUpId: string) => {
     setCheerUpCount(cheerUpCount + 1);
     setIsCheered(true);
     setCheerUpId(cheerUpId);
@@ -129,7 +128,7 @@ const ChallengePage = () => {
     }
   };
 
-  const onCheerUpNotificationEvent = async (cheerUpId) => {
+  const onCheerUpNotificationEvent = async (cheerUpId: string) => {
     const { status } = await fetchPostNotification({
       notificationType: "LIKE",
       notificationTypeId: cheerUpId,
@@ -145,13 +144,13 @@ const ChallengePage = () => {
       item.day === presentDay ? { ...item, isChecked: true } : item
     );
 
-    const { title } = Contents?.data;
+    const { title } = Contents.data;
     const newTitle = { ...JSON.parse(title), days: updatedDays };
 
     const updatedPost = {
       postId,
       title: JSON.stringify(newTitle),
-      image: null,
+      image: null as null,
       channelId,
     };
 
@@ -190,7 +189,11 @@ const ChallengePage = () => {
               >
                 <CommentButton count={commentCount}></CommentButton>
               </Flex>
-              <Flex onClick={onCheerUpEvent}>
+              <Flex
+                onClick={() => {
+                  void onCheerUpEvent();
+                }}
+              >
                 <CheerUpButton
                   isCheered={isCheered}
                   count={cheerUpCount}
@@ -207,7 +210,9 @@ const ChallengePage = () => {
           transform="translate(-50%, 0%)"
           bottom="58px"
           zIndex={2}
-          onClick={onCertificationEvent}
+          onClick={() => {
+            void onCertificationEvent();
+          }}
         >
           <CertificationButton
             isActive={!days[presentDay].isChecked}

--- a/src/pages/ChallengesPage.tsx
+++ b/src/pages/ChallengesPage.tsx
@@ -22,7 +22,7 @@ const ChallengesPage = () => {
       if (status === 200) {
         setChannels(data);
         setSelectedChannel(
-          data.filter((item) => item._id === selectedChannelId)[0]
+          data.filter((item: Channel) => item._id === selectedChannelId)[0]
         );
       } else {
         alert("다시 시도바랍니다!");
@@ -53,8 +53,9 @@ const ChallengesPage = () => {
     setShow(true);
   }, [selectedChannelId]);
 
-  const onClickChips = (event) => {
-    const channelDescription = event.target.dataset.description;
+  const onClickChips = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const target = event.target as HTMLButtonElement;
+    const channelDescription = target.dataset.description;
     const { _id } = channels.filter(
       (item) => item.description === channelDescription
     )[0];

--- a/src/pages/CommentPage.tsx
+++ b/src/pages/CommentPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unsafe-optional-chaining */
 import { useEffect, useState } from "react";
 import { format } from "date-fns";
 import { useAtom } from "jotai";
@@ -8,11 +7,11 @@ import {
   fetchDeleteCommentByPostId,
   fetchPostCommentByPostId,
 } from "@api/comment";
-import { User } from "../types/index";
+import { Comment, User } from "../types/index";
 import { fetchPostNotification } from "@api/notification";
 import { Box, Flex, List, ListItem } from "@chakra-ui/react";
 import DefaultText from "@base/DefaultText";
-import Comment from "@domain/CommentPage/Comment";
+import CommentCard from "@domain/CommentPage/CommentCard";
 import CommentInput from "@domain/CommentPage/CommentInput";
 
 const CommentPage = () => {
@@ -27,7 +26,7 @@ const CommentPage = () => {
 
   useEffect(() => {
     if (Contents?.status === 200) {
-      const { author, comments } = Contents?.data;
+      const { author, comments } = Contents.data;
       setAuthorId(author._id);
       setCommentList(comments);
       setShow(true);
@@ -40,7 +39,7 @@ const CommentPage = () => {
     }
   }, [commentValue]);
 
-  const onCommentNotificationEvent = async (commentId) => {
+  const onCommentNotificationEvent = async (commentId: string) => {
     const { status } = await fetchPostNotification({
       notificationType: "COMMENT",
       notificationTypeId: commentId,
@@ -51,7 +50,7 @@ const CommentPage = () => {
       : console.log("fail comment-notification");
   };
 
-  const setNewCommentList = (data) => {
+  const setNewCommentList = (data: Comment) => {
     setCommentList([...commentList, data]);
     void onCommentNotificationEvent(data._id);
   };
@@ -64,7 +63,7 @@ const CommentPage = () => {
     status === 200 ? setNewCommentList(data) : alert("다시 시도바랍니다!");
   };
 
-  const commentDelete = async (_id) => {
+  const commentDelete = async (_id: string) => {
     const { data, status } = await fetchDeleteCommentByPostId(_id);
     status === 200
       ? setCommentList([
@@ -78,9 +77,11 @@ const CommentPage = () => {
     if (newComment !== "") setCommentValue(newComment);
   };
 
-  const onDeleteCommentEvent = (event) => {
-    if (event.target.tagName === "IMG" && confirm("댓글을 삭제하시겠습니까?")) {
-      const targetCommentId = event.target.closest("li").dataset._id;
+  const onDeleteCommentEvent = (event: React.MouseEvent<HTMLImageElement>) => {
+    const target = event.target as HTMLImageElement;
+    if (target.dataset?.icon !== "icon") return;
+    if (target.tagName === "IMG" && confirm("댓글을 삭제하시겠습니까?")) {
+      const targetCommentId = target.closest("li").dataset._id;
       void commentDelete(targetCommentId);
     }
   };
@@ -106,16 +107,17 @@ const CommentPage = () => {
               }) => {
                 return (
                   <ListItem key={comment._id} data-_id={`${comment._id}`}>
-                    <Comment
+                    <CommentCard
                       isGuest={myUser?._id !== comment.author._id}
                       avatarSrc={comment.author.image}
                       commentAuthor={comment.author.fullName}
+                      commentAuthorId={comment.author._id}
                       commentContent={comment.comment}
                       commentCreatedAt={format(
                         new Date(comment.createdAt),
                         "yyyy-MM-dd HH:mm"
                       )}
-                    ></Comment>
+                    ></CommentCard>
                   </ListItem>
                 );
               }

--- a/src/pages/CreateChallengePage.tsx
+++ b/src/pages/CreateChallengePage.tsx
@@ -7,6 +7,7 @@ import useGetChannelList from "@hooks/quries/useGetChannelList";
 import { fetchPostPostByChannelId } from "@api/post";
 import { useNavigate } from "react-router-dom";
 import usePageTitle from "@hooks/usePageTitle";
+import { Channel } from "src/types";
 
 const challengeTable = Array.from({ length: 30 }, (_, index) => ({
   day: index,
@@ -31,7 +32,7 @@ const CreateChallengePage = () => {
     setChallengeTitle(newChallengeTitle.trim());
   };
   const onChannelChange = (newChannel: string) => {
-    const channelId = channelList.data.filter(({ description }: any) => {
+    const channelId = channelList.data.filter(({ description }: Channel) => {
       return description === newChannel;
     })[0]._id;
     setChannel(channelId);
@@ -61,8 +62,13 @@ const CreateChallengePage = () => {
     }
   };
 
-  const submitChallengeForm = async (newChallenge: any) => {
-    const { status }: any = await fetchPostPostByChannelId({
+  const submitChallengeForm = async (newChallenge: {
+    challengeTitle: string;
+    reward: string;
+    days: { day: number; isChecked: boolean }[];
+    startDate: string;
+  }) => {
+    const { status } = await fetchPostPostByChannelId({
       title: JSON.stringify(newChallenge),
       image: null,
       channelId: channel,
@@ -98,7 +104,7 @@ const CreateChallengePage = () => {
         {channelList && (
           <ChallengeChannelRadio
             onChangeValue={onChannelChange}
-            channelList={channelList.data.map((channel: any) => {
+            channelList={channelList.data.map((channel: Channel) => {
               return channel.description;
             })}
           />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import { Channel, Post } from "../types/index";
 const HomePage = () => {
   const navigate = useNavigate();
   const onClickMore = (channelId: string) => {
-    navigate(`/challenges`);
+    navigate(`/challenges/${channelId}`);
   };
   const onClickChallenge = (channelId: string, challengeId: string): void => {
     navigate(`/challenges/${channelId}/${challengeId}`);

--- a/src/stories/domain/CommentPage/Comment.stories.tsx
+++ b/src/stories/domain/CommentPage/Comment.stories.tsx
@@ -1,16 +1,23 @@
-import Comment from "@domain/CommentPage/Comment";
+import CommentCard from "@domain/CommentPage/CommentCard";
 import GlobalStyles from "src/styles/GlobalStyles";
 
 export default {
-  title: "Domain/CommentPage/Comment",
-  component: Comment,
+  title: "Domain/CommentPage/CommentCard",
+  component: CommentCard,
 };
 
 export const Default = () => {
   return (
     <>
       <GlobalStyles />
-      <Comment></Comment>
+      <CommentCard
+        isGuest={true}
+        avatarSrc={undefined}
+        commentAuthor={"commentAuthor"}
+        commentAuthorId={"example"}
+        commentContent={"storybook comment"}
+        commentCreatedAt={"2022.06.23 05:23"}
+      ></CommentCard>
     </>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noEmit": true,
     "jsx": "react-jsx"
   },


### PR DESCRIPTION
## 📌 기능 설명
- noImplicitAny true 설정
- commentPage 아바타 클릭시 댓글 삭제하는 버그 수정
- comment 클릭 시 해당 유저페이지로 이동

## 👩‍💻 요구 사항과 구현 내용 
- noImplicitAny
   - true로 설정하고 모든 any type 제거
- commentPage 아바타 클릭시 댓글 삭제하는 버그 수정
   - 기존에는 CommentCard 안에 삭제 버튼만 `img`태그이었는데 Avatar의 img를 적용하게되어 Avatar를 클릭하면 댓글 삭제하는 로직을 실행하는 버그를 발견
   - 삭제하는 버튼에 dataset를 추가하여 분기하여 처리
- comment 클릭 시 해당 유저페이지로 이동
   - 댓글 페이지에서 댓글의 Avatar 또는 username을 클릭하면 해당 유저페이지로 이동하는 기능 추가

### 피드백
- 더 브랜치를 나눠 작업해야겠다는 아쉬움과 함께 깨달음을 얻었습니다.