### PR TITLE
[refactor] 프로필이미지 변경- 낙관적 업데이트 

### DIFF
--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -13,6 +13,8 @@ import usePageTitle from "@hooks/usePageTitle";
 import { fetchPostUserProfileImage } from "@api/user";
 import { useMutation } from "react-query";
 
+import { User } from "../types/index";
+
 const EditProfilePage = () => {
   const toast = useToast();
   usePageTitle("프로필 설정");
@@ -82,8 +84,23 @@ const EditProfilePage = () => {
       });
   };
 
-  const uploadProfileImage = useMutation((fd: FormData) =>
-    fetchPostUserProfileImage(fd)
+  const uploadProfileImage = useMutation(
+    (fd: FormData) => fetchPostUserProfileImage(fd),
+    {
+      onMutate: () => {
+        toast({
+          title: "프로필 이미지 변경을 성공했습니다!",
+          description: "프로필 이미지 변경 성공",
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        });
+        navigate("/my/profile");
+      },
+      onSuccess: (data: User) => {
+        setMyUser(data);
+      },
+    }
   );
 
   const profileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -92,19 +109,7 @@ const EditProfilePage = () => {
     fd.append("isCover", "false");
     fd.append("image", imageFile);
 
-    uploadProfileImage.mutate(fd, {
-      onSuccess: (data) => {
-        setMyUser(data);
-        navigate("/my/profile");
-        toast({
-          title: "프로필 이미지 변경을 성공했습니다!",
-          description: "프로필 이미지 변경 성공",
-          status: "success",
-          duration: 3000,
-          isClosable: true,
-        });
-      },
-    });
+    uploadProfileImage.mutate(fd);
   };
 
   return (

--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -11,6 +11,7 @@ import userAtom from "@store/user";
 import { deleteTokenFromLocalStorage } from "@lib/localStorage";
 import usePageTitle from "@hooks/usePageTitle";
 import { fetchPostUserProfileImage } from "@api/user";
+import { useMutation } from "react-query";
 
 const EditProfilePageContainer = styled.div`
   display: flex;
@@ -135,14 +136,20 @@ const EditProfilePage = () => {
       });
   };
 
+  const uploadProfileImage = useMutation((fd: FormData) =>
+    fetchPostUserProfileImage(fd)
+  );
+
   const profileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fd = new FormData();
     const imageFile = e.target.files[0];
     fd.append("isCover", "false");
     fd.append("image", imageFile);
 
-    fetchPostUserProfileImage(fd)
-      .then(() => {
+    uploadProfileImage.mutate(fd, {
+      onSuccess: (data) => {
+        setMyUser(data);
+        navigate("/my/profile");
         toast({
           title: "프로필 이미지 변경을 성공했습니다!",
           description: "프로필 이미지 변경 성공",
@@ -150,11 +157,8 @@ const EditProfilePage = () => {
           duration: 3000,
           isClosable: true,
         });
-        navigate("/my/profile");
-      })
-      .catch((e) => {
-        console.log(e);
-      });
+      },
+    });
   };
 
   return (

--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -13,60 +13,6 @@ import usePageTitle from "@hooks/usePageTitle";
 import { fetchPostUserProfileImage } from "@api/user";
 import { useMutation } from "react-query";
 
-const EditProfilePageContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: white;
-  margin-top: 40px;
-  padding-top: 40px;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-`;
-
-const ChangeButton = styled(Button)`
-  color: white;
-  background-color: #ffaa6d;
-  margin: 12px;
-
-  &:hover {
-    background-color: #ff7900;
-  }
-`;
-
-const FormContainer = styled.div`
-  margin-top: 36px;
-  margin-bottom: 36px;
-`;
-
-const ProfileImageButton = styled.label`
-  padding: 6px 25px;
-  background-color: #ff6600;
-  border-radius: 4px;
-  color: white;
-  cursor: pointer;
-`;
-
-const CFlex = styled(Flex)`
-  align-items: center;
-`;
-
-const InfoText = styled.div`
-  width: 100px;
-  font-size: 16px;
-  font-weight: 400;
-`;
-
-const CInput = styled(Input)`
-  width: 70%;
-  outline: none;
-`;
-
-const LogoutButton = styled(Button)`
-  color: #838489;
-  background-color: #f4f6f8;
-  margin-bottom: 40px;
-`;
-
 const EditProfilePage = () => {
   const toast = useToast();
   usePageTitle("프로필 설정");
@@ -204,3 +150,57 @@ const EditProfilePage = () => {
 };
 
 export default EditProfilePage;
+
+const EditProfilePageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: white;
+  margin-top: 40px;
+  padding-top: 40px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
+
+const ChangeButton = styled(Button)`
+  color: white;
+  background-color: #ffaa6d;
+  margin: 12px;
+
+  &:hover {
+    background-color: #ff7900;
+  }
+`;
+
+const FormContainer = styled.div`
+  margin-top: 36px;
+  margin-bottom: 36px;
+`;
+
+const ProfileImageButton = styled.label`
+  padding: 6px 25px;
+  background-color: #ff6600;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+`;
+
+const CFlex = styled(Flex)`
+  align-items: center;
+`;
+
+const InfoText = styled.div`
+  width: 100px;
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+const CInput = styled(Input)`
+  width: 70%;
+  outline: none;
+`;
+
+const LogoutButton = styled(Button)`
+  color: #838489;
+  background-color: #f4f6f8;
+  margin-bottom: 40px;
+`;

--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -100,6 +100,7 @@ const EditProfilePage = () => {
       onSuccess: (data: User) => {
         setMyUser(data);
       },
+      mutationKey: "uploadProfileImage",
     }
   );
 

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -6,14 +6,6 @@ import MySummary from "@domain/ProfilePage/MySummary";
 import userAtom from "@store/user";
 import usePageTitle from "@hooks/usePageTitle";
 
-const UserInfo = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-  margin-top: 32px;
-`;
-
 const MyProfilePage = () => {
   const [myUser] = useAtom(userAtom);
   usePageTitle(myUser.fullName);
@@ -35,3 +27,11 @@ const MyProfilePage = () => {
 };
 
 export default MyProfilePage;
+
+const UserInfo = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  margin-top: 32px;
+`;


### PR DESCRIPTION
## 📌 기능 설명 
결론은 프로필이미지 변경은 낙관적 업데이트가 불가능합니다. 대신, 이미지 변경 성공 알림과 페이지 navigate는 가능합니다
- 프로필 이미지 변경이 낙관적 업데이트가 불가능한 이유는, 서버로부터 이미지 url을 받아야하기 떄문입니다
- 낙관적 업데이트는 서버 응답과 상관없이 일단 UI를 변경하고 보는 것입니다. 그런데 현재 프로필 이미지는 서버 응답의 url값입니다. 그래서 응답이 오기전에는 낙관적 업데이트가 불가능합니다

- 리액트 쿼리에서 낙관적 업데이트를 사용하는 옵션은 `onMutate` 입니다

- 요청이 실패하면 onError 옵션으로 에러처리를 해주어야하지만.... 다음 회의때 얘기하는걸로 하겠습니다.

## 👩‍💻 요구 사항과 구현 내용 
- onMutate 옵션으로 서버 응답 상관없이 성공알림과 navigation을 합니다.
- onSuccess 옵션을 사용하여 서버 응답값으로 프로필 이미지 변경합니다
## 구현 결과
