### PR TITLE
[Refactor] follow page tab 상태 추가

### DIFF
--- a/src/components/domain/FollowPage/FollowPageTab.tsx
+++ b/src/components/domain/FollowPage/FollowPageTab.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { User } from "src/types";
 import {
   Tab,
@@ -20,7 +20,8 @@ interface Props {
 }
 
 const FollowPageTab = ({ followingList, followersList }: Props) => {
-  const [selectedTab, setSelectedTab] = useState(0);
+  const tab = useLocation().state;
+  const [selectedTab, setSelectedTab] = useState(tab === "following" ? 1 : 0);
   const navigate = useNavigate();
   const handleClickUser = (userId: string) => {
     navigate(`/profile/${userId}`);

--- a/src/components/domain/ProfilePage/MySummary.tsx
+++ b/src/components/domain/ProfilePage/MySummary.tsx
@@ -48,8 +48,8 @@ const MySummary = ({
 }: UserSummaryProps) => {
   const navigate = useNavigate();
 
-  const handleFollowingClick = () => {
-    navigate(`/follow/${id}`);
+  const handleFollowingClick = (tab: "following" | "follower") => {
+    navigate(`/follow/${id}`, { state: tab });
   };
 
   return (
@@ -57,11 +57,23 @@ const MySummary = ({
       <IntroduceText textAlign="center">{introduce}</IntroduceText>
       <FollowContainer>
         <div>
-          <Text onClick={handleFollowingClick}>{followerCount}</Text>
+          <Text
+            onClick={() => {
+              handleFollowingClick("follower");
+            }}
+          >
+            {followerCount}
+          </Text>
           <div>팔로워</div>
         </div>
         <div>
-          <Text onClick={handleFollowingClick}>{followingCount}</Text>
+          <Text
+            onClick={() => {
+              handleFollowingClick("following");
+            }}
+          >
+            {followingCount}
+          </Text>
           <div>팔로잉</div>
         </div>
       </FollowContainer>

--- a/src/components/domain/ProfilePage/MySummary.tsx
+++ b/src/components/domain/ProfilePage/MySummary.tsx
@@ -2,16 +2,67 @@ import { Button, Text } from "@chakra-ui/react";
 import styled from "@emotion/styled";
 import { Link, useNavigate } from "react-router-dom";
 
-interface UserSummaryProps {
+interface Props {
   introduce: string;
   followerCount: number;
   followingCount: number;
   id: string;
 }
 
-const IntroduceText = styled(Text)`
-  padding-top: 32px;
-`;
+const MySummary = ({ introduce, followerCount, followingCount, id }: Props) => {
+  const navigate = useNavigate();
+
+  const handleFollowingClick = (tab: "following" | "follower") => {
+    navigate(`/follow/${id}`, { state: tab });
+  };
+
+  return (
+    <UserSummaryContainer>
+      <Text padding-top="32px" textAlign="center">
+        {introduce}
+      </Text>
+      <FollowContainer>
+        <div>
+          <Text
+            _hover={{ cursor: "pointer" }}
+            onClick={() => {
+              handleFollowingClick("follower");
+            }}
+          >
+            {followerCount}
+          </Text>
+          <div>팔로워</div>
+        </div>
+        <div>
+          <Text
+            _hover={{ cursor: "pointer" }}
+            onClick={() => {
+              handleFollowingClick("following");
+            }}
+          >
+            {followingCount}
+          </Text>
+          <div>팔로잉</div>
+        </div>
+      </FollowContainer>
+      <div>
+        <Link to={`${location.pathname}/edit`}>
+          <Button
+            width="100%"
+            color="white"
+            backgroundColor="#ffaa6d"
+            marginTop="12px"
+            _hover={{ backgroundColor: "#ff7900" }}
+          >
+            프로필 수정
+          </Button>
+        </Link>
+      </div>
+    </UserSummaryContainer>
+  );
+};
+
+export default MySummary;
 
 const UserSummaryContainer = styled.div`
   width: 50%;
@@ -28,62 +79,3 @@ const FollowContainer = styled.div`
     font-weight: 700;
   }
 `;
-
-const CButton = styled(Button)`
-  width: 100%;
-  color: white;
-  background-color: #ffaa6d;
-  margin-top: 12px;
-
-  &:hover {
-    background-color: #ff7900;
-  }
-`;
-
-const MySummary = ({
-  introduce,
-  followerCount,
-  followingCount,
-  id,
-}: UserSummaryProps) => {
-  const navigate = useNavigate();
-
-  const handleFollowingClick = (tab: "following" | "follower") => {
-    navigate(`/follow/${id}`, { state: tab });
-  };
-
-  return (
-    <UserSummaryContainer>
-      <IntroduceText textAlign="center">{introduce}</IntroduceText>
-      <FollowContainer>
-        <div>
-          <Text
-            onClick={() => {
-              handleFollowingClick("follower");
-            }}
-          >
-            {followerCount}
-          </Text>
-          <div>팔로워</div>
-        </div>
-        <div>
-          <Text
-            onClick={() => {
-              handleFollowingClick("following");
-            }}
-          >
-            {followingCount}
-          </Text>
-          <div>팔로잉</div>
-        </div>
-      </FollowContainer>
-      <div>
-        <Link to={`${location.pathname}/edit`}>
-          <CButton>프로필 수정</CButton>
-        </Link>
-      </div>
-    </UserSummaryContainer>
-  );
-};
-
-export default MySummary;

--- a/src/components/domain/ProfilePage/OtherSummary.tsx
+++ b/src/components/domain/ProfilePage/OtherSummary.tsx
@@ -3,50 +3,19 @@ import { Button, Text } from "@chakra-ui/react";
 import styled from "@emotion/styled";
 import { useNavigate } from "react-router-dom";
 
-interface UserSummaryProps {
+interface Props {
   introduce: string;
   followerCount: number;
   followingCount: number;
   id: string;
 }
 
-const IntroduceText = styled(Text)`
-  padding-top: 32px;
-`;
-
-const UserSummaryContainer = styled.div`
-  width: 50%;
-  display: block;
-  text-align: center;
-`;
-
-const FollowContainer = styled.div`
-  display: flex;
-  justify-content: space-evenly;
-  margin-top: 40px;
-
-  & p {
-    font-weight: 700;
-  }
-`;
-
-const CButton = styled(Button)`
-  width: 100%;
-  color: white;
-  background-color: #ffaa6d;
-  margin-top: 12px;
-
-  &:hover {
-    background-color: #ff7900;
-  }
-`;
-
 const OtherSummary = ({
   introduce,
   followerCount,
   followingCount,
   id,
-}: UserSummaryProps) => {
+}: Props) => {
   const navigate = useNavigate();
 
   const handleFollowingClick = (tab: "follower" | "following") => {
@@ -61,7 +30,9 @@ const OtherSummary = ({
 
   return (
     <UserSummaryContainer>
-      <IntroduceText textAlign="center">{introduce}</IntroduceText>
+      <Text textAlign="center" padding-top="32px">
+        {introduce}
+      </Text>
       <FollowContainer>
         <div>
           <Text
@@ -87,10 +58,35 @@ const OtherSummary = ({
         </div>
       </FollowContainer>
       <div>
-        <CButton onClick={handleFollowClick}>팔로우</CButton>
+        <Button
+          width="100%"
+          color="white"
+          backgroundColor="#ffaa6d"
+          marginTop="12px"
+          _hover={{ backgroundColor: "#ff7900" }}
+          onClick={handleFollowClick}
+        >
+          팔로우
+        </Button>
       </div>
     </UserSummaryContainer>
   );
 };
 
 export default OtherSummary;
+
+const UserSummaryContainer = styled.div`
+  width: 50%;
+  display: block;
+  text-align: center;
+`;
+
+const FollowContainer = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  margin-top: 40px;
+
+  & p {
+    font-weight: 700;
+  }
+`;

--- a/src/components/domain/ProfilePage/OtherSummary.tsx
+++ b/src/components/domain/ProfilePage/OtherSummary.tsx
@@ -49,8 +49,8 @@ const OtherSummary = ({
 }: UserSummaryProps) => {
   const navigate = useNavigate();
 
-  const handleFollowingClick = () => {
-    navigate(`/follow/${id}`);
+  const handleFollowingClick = (tab: "follower" | "following") => {
+    navigate(`/follow/${id}`, { state: tab });
   };
 
   const handleFollowClick = () => {
@@ -64,11 +64,25 @@ const OtherSummary = ({
       <IntroduceText textAlign="center">{introduce}</IntroduceText>
       <FollowContainer>
         <div>
-          <Text onClick={handleFollowingClick}>{followerCount}</Text>
+          <Text
+            _hover={{ cursor: "pointer" }}
+            onClick={() => {
+              handleFollowingClick("follower");
+            }}
+          >
+            {followerCount}
+          </Text>
           <div>팔로워</div>
         </div>
         <div>
-          <Text onClick={handleFollowingClick}>{followingCount}</Text>
+          <Text
+            _hover={{ cursor: "pointer" }}
+            onClick={() => {
+              handleFollowingClick("following");
+            }}
+          >
+            {followingCount}
+          </Text>
           <div>팔로잉</div>
         </div>
       </FollowContainer>


### PR DESCRIPTION
## 📌 기능 설명 
- 팔로우 / 팔로워 클릭 시 해당 tab이 보여짐
## 👩‍💻 요구 사항과 구현 내용 
#### 요구 사항과 실제 구현 내용을 작성해 주세요.
react router dom의 useNavigate을 이용할 때 
state를 사용해서  profile 페이지에서 follow page로 넘어갈 때  무조건 팔로우 탭이 보였는데 state를 둬서 각각 알맞는 탭이 열리게 바꿨습니다.

```js
 const handleFollowingClick = (tab: "follower" | "following") => {
    navigate(`/follow/${id}`, { state: tab });
  };
```

### 논의하고 싶은 점
-  위와 같이 작성할 때 tab에 숫자가 아닌 문자열로 넘겨주었는데, 사실 사용할 때에는 숫자로 tab을 설정합니다.
```js
  const tab = useLocation().state;
  const [selectedTab, setSelectedTab] = useState(tab === "following" ? 1 : 0);
``` 

이런식으로 처리하고 있는데, 아예 tab에서부터 숫자로 받아오는 것이 좋을까요?
코드를 이해하기에는 문자열로 받아오는 것이, 깔끔한 것은 숫자로 처리하는 것이 좋은 것 같습니다. 
