### PR TITLE
[Refactor] window이벤트 제거, 새로고침시 채널 선택 버그 수정

### DIFF
--- a/src/pages/ChallengesPage.tsx
+++ b/src/pages/ChallengesPage.tsx
@@ -5,63 +5,47 @@ import Chips from "@domain/ChallengesPage/Chips";
 import useChallenges from "@hooks/quries/useChallenges";
 import useChannels from "@hooks/quries/useChannels";
 import usePageTitle from "@hooks/usePageTitle";
-import { Channel, Post } from "src/types";
+import { useNavigate, useParams } from "react-router-dom";
+import { Channel } from "src/types";
 
 const ChallengesPage = () => {
   usePageTitle("채널");
-  const [selectedChannelId, setSelectedChannelId] = useState(
-    window.location.pathname.split("/")[2]
-  );
-  const { data: channelsData } = useChannels();
-  const { data: challengesData } = useChallenges(selectedChannelId);
-  const [channels, setChannels] = useState<Channel[]>(); // 채널 목록 데이터전체
-  const [challenges, setChallenges] = useState<Post[]>(); // 선택된 채널의 포스트 목록
+  const navigate = useNavigate();
+  const { channelId } = useParams();
+  const { data: channelsData } = useChannels(); // 채널 목록 데이터전체
+  const { data: challengesData } = useChallenges(channelId); // 선택된 채널의 포스트 목록
   const [selectedChannel, setSelectedChannel] = useState<Channel>(); // 선택된 채널 데이터전체
 
-  const windowListener = () => {
-    const clickedChannel = window.location.pathname.split("/")[2];
-    setSelectedChannelId(clickedChannel);
-  };
-
   useEffect(() => {
-    setChannels(channelsData);
-
-    window.addEventListener("popstate", windowListener);
-    return () => {
-      window.removeEventListener("popstate", windowListener);
-    };
+    setSelectedChannel(
+      channelsData?.filter((item: Channel) => item._id === channelId)[0]
+    );
   }, [channelsData]);
 
   useEffect(() => {
-    setChallenges(challengesData);
-  }, [challengesData]);
-
-  useEffect(() => {
-    setChallenges(challengesData);
-    const clickedChannel = channels?.filter(
-      (item) => item._id === selectedChannelId
+    const clickedChannel = channelsData?.filter(
+      (item) => item._id === channelId
     )[0];
     setSelectedChannel(clickedChannel);
-  }, [selectedChannelId]);
+  }, [channelId]);
 
   const onClickChips = (event: React.MouseEvent<HTMLButtonElement>) => {
     const target = event.target as HTMLButtonElement;
     const channelDescription = target.dataset.description;
-    const { _id } = channels.filter(
+    const { _id } = channelsData.filter(
       (item) => item.description === channelDescription
     )[0];
-    setSelectedChannelId(_id);
-    history.pushState(null, null, `/challenges/${_id}`);
+    navigate(`/challenges/${_id}`);
   };
 
   return (
     <>
       <Chips
-        names={(channels || []).map((challenge) => challenge.description)}
+        names={(channelsData || []).map((challenge) => challenge.description)}
         selectedChip={selectedChannel?.description || "독서"}
         onClickProp={onClickChips}
       />
-      <Challenges posts={challenges || []} />
+      <Challenges posts={challengesData || []} />
     </>
   );
 };


### PR DESCRIPTION
## 📌 기능 설명
- window 이벤트 제거
   - 뒤로가기 이벤트를 감지하여 화면을 고치는 작업을 리팩토링하였습니다.
- 새로고침 시 채널 선택 버그 수정
   - 기존 코드의 제거로 인해 새로고침시 채널이 선택되는 작업이 제거되었는데 재구현하였습니다.

## 👩‍💻 요구 사항과 구현 내용
- window 이벤트 제거
   - pushstate 부분은 react-router의 `navigate`를 이용하였습니다.
   - popstate 부분은 react-router의 `useParams`로 변동될 때마다 채널ID를 받아서 채널의 목표 목록을 보여주도록 구현하였습니다.
- 새로고침 시 채널 선택 버그 수정 (아래 코드 추가)
```js
const clickedChannel = channelsData?.filter(
  (item) => item._id === channelId
)[0];
setSelectedChannel(clickedChannel);
```

## 🔍피드백
- 채널 페이지의 38번째 줄에서 typescript오류가 나오는데 해결하지 못하였습니다.
- 하지만 화면 렌더링에는 오류없이 나와서 일단 PR올립니다. 혹시나 관련하여 아시는 분 계시면 코멘트 부탁드립니다.
<img width="1029" alt="스크린샷 2022-07-18 05 20 01" src="https://user-images.githubusercontent.com/75886763/179423492-ff60e971-91f3-4faa-8575-69b8441dfae9.png">
